### PR TITLE
Track Clock, Calendar APPs for VANILLA

### DIFF
--- a/snippets/aosip.xml
+++ b/snippets/aosip.xml
@@ -93,6 +93,7 @@
   <project path="packages/apps/CellBroadcastReceiver" name="platform_packages_apps_CellBroadcastReceiver" remote="derp" />
   <project path="packages/apps/CertInstaller" name="platform_packages_apps_CertInstaller" remote="derp" />
   <project path="packages/apps/Contacts" name="platform_packages_apps_Contacts" remote="aosip" />
+  <project path="packages/apps/DeskClock" name="platform_packages_apps_DeskClock" remote="aosip" />
   <project path="packages/apps/Dialer" name="platform_packages_apps_Dialer" remote="aosip" />
   <project path="packages/apps/DocumentsUI" name="platform_packages_apps_DocumentsUI" remote="aosip" />
   <project path="packages/apps/Launcher3" name="platform_packages_apps_Launcher3" remote="aosip" />

--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -103,6 +103,7 @@
   <!-- Packages -->
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="lineage" />
   <project path="packages/apps/ExactCalculator" name="android_packages_apps_ExactCalculator" remote="lineage" />
+  <project path="packages/apps/Etar" name="android_packages_apps_Etar" remote="lineage" />
 
   <!-- Prebuilts -->
   <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" name="android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9" remote="lineage" clone-depth="1" />


### PR DESCRIPTION
Now only track Etar Calendar and DeskClock repos in manifests. Prebuilts repo already has.